### PR TITLE
Increased reset duration in simulation

### DIFF
--- a/sim/src/top.sv
+++ b/sim/src/top.sv
@@ -157,7 +157,7 @@ module top (
 ///////////////////////////////////////////////////////////////////
 
 
-    parameter RESET_CYCLES = 9;
+    parameter RESET_CYCLES = 25;
     reg              tlx_clock;
     reg              afu_clock;
     reg              reset;

--- a/sim/src/unit_top.sv
+++ b/sim/src/unit_top.sv
@@ -34,7 +34,7 @@ module unit_top (
 //**********************************************
 // CLOCK & RESET
 //**********************************************
-parameter        RESET_CYCLES = 9;
+parameter        RESET_CYCLES = 25;
 integer          resetCnt;
 reg              clock_400m;
 reg              clock_200m;


### PR DESCRIPTION
The reset counter is active at both clock edges, and performed in the 400MHz domain.
This caused the reset to be asserted for only 2 clock cycles in the 200MHz domain, which is too short for some designs.