### PR TITLE
Fix ILA error in HBM-enabled designs for the 9H7.

### DIFF
--- a/board_support_packages/ad9h7/xdc/main_placement_bypass.xdc
+++ b/board_support_packages/ad9h7/xdc/main_placement_bypass.xdc
@@ -47,3 +47,8 @@ set_property EXTRACT_RESET NO [get_cells {bsp?/tlx/OCX_TLX_PARSER/TLX_RCV_FIFO/C
 set_property EXTRACT_RESET NO [get_cells {bsp?/dlx_phy/ocx_dlx_top_inst/tx/flt/pre_crc_data_q_reg[*]}]
 set_property EXTRACT_RESET NO [get_cells {bsp?/tlx/OCX_TLX_PARSER/TLX_RCV_FIFO/RESP_FIFO_MAC/RESP_INFO_CTL/data_wr_cnt_dout_reg[*]}]
 set_property EXTRACT_RESET NO [get_cells {bsp?/tlx/OCX_TLX_PARSER/TLX_RCV_FIFO/CMD_FIFO_MAC/CMD_INFO_CTL/data_wr_cnt_dout_reg[*]}]
+
+set_property C_CLK_INPUT_FREQ_HZ 300000000 [get_debug_cores dbg_hub]
+set_property C_ENABLE_CLK_DIVIDER false [get_debug_cores dbg_hub]
+set_property C_USER_SCAN_CHAIN 1 [get_debug_cores dbg_hub]
+connect_debug_port dbg_hub/clk [get_nets oc0_clock_tlx]


### PR DESCRIPTION
When building HBM-enabled designs for the 9H7, an error would occur during opt_design when ILA was disabled.
This was because Vivado automatically adds a dbg_hub component in the HBM IP, which had an unconnected clock port.
This code connects that port to one of the clocks, resolving the error.